### PR TITLE
Fix: 출발시간 모달 UI 깨짐 해결 및 시간 선택 버그 수정

### DIFF
--- a/src/Screens/CreatePotPage/CreatePotModal.tsx
+++ b/src/Screens/CreatePotPage/CreatePotModal.tsx
@@ -44,15 +44,17 @@ function CreatePotModal() {
     <View style={styles.modalWrapper}>
       <View style={styles.modal}>
         <Text style={styles.startText}>출발시간</Text>
-        <DateTimePicker
-          testID="dateTimePicker"
-          value={timestamp}
-          mode="datetime"
-          display="spinner"
-          onChange={onChange}
-          textColor="black"
-          locale="ko"
-        />
+        <View style={{ marginTop: 20 }}>
+          <DateTimePicker
+            testID="dateTimePicker"
+            value={timestamp}
+            mode="datetime"
+            display="spinner"
+            onChange={onChange}
+            textColor="black"
+            locale="ko"
+          />
+        </View>
         <Pressable
           style={{
             height: 48,

--- a/src/Screens/CreatePotPage/CreatePotModal.tsx
+++ b/src/Screens/CreatePotPage/CreatePotModal.tsx
@@ -97,18 +97,17 @@ const styles = StyleSheet.create({
   modal: {
     position: "absolute",
     width: "79%",
-    height: "44%",
+    height: "50%",
     backgroundColor: "white",
     zIndex: 11,
     justifyContent: "center",
     alignItems: "center",
     borderRadius: 12,
-    gap: 20,
+    gap: 10,
   },
   startText: {
     fontSize: 19,
     fontWeight: "700",
-    marginTop: 20,
   },
   selectedText: {
     color: "#FFF",

--- a/src/Screens/CreatePotPage/CreatePotModal.tsx
+++ b/src/Screens/CreatePotPage/CreatePotModal.tsx
@@ -32,10 +32,11 @@ function CreatePotModal() {
     // 선택한 시간이 있으면 그 시간으로 설정, 없으면 현재 시간으로 설정
     const currentDate = selectedDate || today;
     //모달에서 선택한 시간을 timestamp로 변환
-    setTimestamp(new Date(currentDate.getTime() + KR_TIME_DIFF));
+    setTimestamp(new Date(currentDate.getTime()));
   };
   const onPress = () => {
-    setSelectedTime(timestamp);
+    const selectedTime = new Date(timestamp.getTime() + KR_TIME_DIFF);
+    setSelectedTime(selectedTime);
     setModalVisible(false);
   };
 


### PR DESCRIPTION
close #49 
## Key Changes
- DateTimePicker의 value를 today로 하니 시각을 돌려도 계속 현재 시각으로 돌아왔습니다.
- 이를 위해 timestamp로 설정해주었는데, timestamp는 currentDate + 시차 보정을 한 값이라 DateTimePicker의 값이 또 변경되었습니다. 
- 따라서 timestamp에 시차 보정을 하지 않고, onPress 함수가 작동 될 때 시차 보정을 해주었습니다.

## 스크린
![IMG_9913](https://github.com/TeamFighting/MoyeoTa-Mobile/assets/108210492/64f88616-f04c-4cc5-aab8-42f12bdb1155)
샷
<img width="500" alt="image" src="https://github.com/TeamFighting/MoyeoTa-Mobile/assets/108210492/89ede0eb-753b-44d4-ab52-530f9d5891cd">

## To Reviewers

~를 중점으로 보면서 검토해주세요
