### PR TITLE
Feat: 닉네임 설정 기능 개발 및 프로필 이미지 border 삭제

### DIFF
--- a/src/Screens/MyPage/Components/UserInfo.tsx
+++ b/src/Screens/MyPage/Components/UserInfo.tsx
@@ -44,7 +44,9 @@ function UserInfo() {
                 fontStyle: "normal",
               }}
             >
-              {myInfo.name}
+              {myInfo.nickname != null || myInfo.nickname != ""
+                ? myInfo.nickname
+                : myInfo.name}
             </Text>
             <PencilIcon />
           </View>

--- a/src/Screens/MyPage/UpdateProfilePage.tsx
+++ b/src/Screens/MyPage/UpdateProfilePage.tsx
@@ -20,7 +20,7 @@ import { useAuthStore } from "../../libs/states/authStore";
 function UpdateProfile() {
   const navigation = useNavigation();
   const [name, setName] = useState("");
-  const { myInfo } = useMyInfoStore();
+  const { myInfo, setMyInfo } = useMyInfoStore();
   const { token } = useAuthStore();
 
   const onChangeName = (inputName: string) => {
@@ -29,8 +29,8 @@ function UpdateProfile() {
 
   async function setNickName() {
     console.log("HERE");
-    console.log(name);
     console.log(token);
+    setMyInfo({ ...myInfo, nickname: name });
     try {
       const response = await axios.put(
         "https://moyeota.shop/api/users/nickname",
@@ -39,11 +39,15 @@ function UpdateProfile() {
         },
         {
           headers: {
-            AuthorizationCode: token,
+            Authorization: `Bearer ${token}`,
           },
         }
       );
-      console.log("res", response);
+      console.log(response.data.data);
+      if (response.status === 200) {
+        alert("닉네임이 변경되었습니다.");
+        navigation.goBack();
+      }
     } catch (e) {
       console.log("Nickname", e);
     }

--- a/src/Screens/MyPage/styles.ts
+++ b/src/Screens/MyPage/styles.ts
@@ -44,6 +44,7 @@ export const Styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
     borderWidth: 1,
+    borderColor: "none",
   },
   Tag: {
     height: 20,


### PR DESCRIPTION
close #47 
## Motivation
- 닉네임 API 연동을 통해 닉네임을 설정하도록 했습니다.
- 만일 닉네임이 등록되지 않은 경우, 이름으로 설정되어있고, 닉네임을 새로 등록할 경우 닉네임으로 활동하도록 구현했습니다.

## Key Changes
- 프로필 이미지에 border이 있어 이를 제거했습니다.

## 스크린샷
![47:닉네임 구현](https://github.com/TeamFighting/MoyeoTa-Mobile/assets/108210492/02b42156-28f3-4654-a38b-d138ac0d2d85)


